### PR TITLE
Make sure writing to the onces map is done with the lock

### DIFF
--- a/emitter.go
+++ b/emitter.go
@@ -137,7 +137,11 @@ func (emitter *Emitter) Once(event, listener interface{}) *Emitter {
 		fn.Call(values)
 	}
 
+	// Lock before changing onces
+	emitter.Lock()
 	emitter.onces[fn] = reflect.ValueOf(run)
+	emitter.Unlock()
+
 	emitter.AddListener(event, run)
 	return emitter
 }


### PR DESCRIPTION
We've updated to go1.6 and the new concurrent map misuse code is firing here:

It looks like onces is being written without the mutex.

```
fatal error: concurrent map writes

goroutine 19369 [running]:
runtime.throw(0xf6d140, 0x15)
        /opt/lib/Go_1.6/src/runtime/panic.go:530 +0x90 fp=0xc821308710 sp=0xc8213086f8
runtime.mapassign1(0xbb8c60, 0xc82046b1a0, 0xc821308850, 0xc821308838)
        /opt/lib/Go_1.6/src/runtime/hashmap.go:445 +0xb1 fp=0xc8213087b8 sp=0xc821308710
github.com/chuckpreslar/emission.(*Emitter).Once(0xc82046b140, 0xbbcb60, 0xc8208a5330, 0xbd0760, 0xc8208a5320, 0xc820c608d0)
        /app/src/github.com/chuckpreslar/emission/emitter.go:140 +0x2b9 fp=0xc821308870 sp=0xc8213087b8
```