### PR TITLE
Simple accessor for the number of listeners for a given event

### DIFF
--- a/emitter.go
+++ b/emitter.go
@@ -289,13 +289,14 @@ func (emitter *Emitter) SetMaxListeners(max int) *Emitter {
 	return emitter
 }
 
-// Here is a count function
-func (emitter *Emitter) GetListenersCount(event interface{}) int {
+// GetListenerCount gets count of listeners for a given event.
+func (emitter *Emitter) GetListenerCount(event interface{}) (count int) {
+	emitter.Lock()
 	if listeners, ok := emitter.events[event]; ok {
-		return len(listeners)
+		count = len(listeners)
 	}
-
-	return 0
+	emitter.Unlock()
+	return
 }
 
 // NewEmitter returns a new Emitter object, defaulting the

--- a/emitter.go
+++ b/emitter.go
@@ -289,6 +289,15 @@ func (emitter *Emitter) SetMaxListeners(max int) *Emitter {
 	return emitter
 }
 
+// Here is a count function
+func (emitter *Emitter) GetListenersCount(event interface{}) int {
+	if listeners, ok := emitter.events[event]; ok {
+		return len(listeners)
+	}
+
+	return 0
+}
+
 // NewEmitter returns a new Emitter object, defaulting the
 // number of maximum listeners per event to the DefaultMaxListeners
 // constant and initializing its events map.

--- a/emitter_test.go
+++ b/emitter_test.go
@@ -47,11 +47,11 @@ func TestEmitWithMultipleListeners(t *testing.T) {
 
 	NewEmitter().
 		AddListener(event, func() {
-		invoked = invoked + 1
-	}).
+			invoked = invoked + 1
+		}).
 		AddListener(event, func() {
-		invoked = invoked + 1
-	}).
+			invoked = invoked + 1
+		}).
 		Emit(event)
 
 	if invoked != 2 {
@@ -112,5 +112,20 @@ func TestRemoveOnce(t *testing.T) {
 
 	if flag {
 		t.Error("Failed to remove Listener for Once")
+	}
+}
+
+func TestCountListener(t *testing.T) {
+	event := "test"
+
+	emitter := NewEmitter().
+		AddListener(event, func() {})
+
+	if 1 != emitter.GetListenerCount(event) {
+		t.Error("Failed to get listener count from emitter.")
+	}
+
+	if 0 != emitter.GetListenerCount("fake") {
+		t.Error("Failed to get listener count from emitter.")
 	}
 }


### PR DESCRIPTION
We track the number of emitters for certain events, so we need to access this count safely.