### PR TITLE
Support removal of struct methods

### DIFF
--- a/emitter.go
+++ b/emitter.go
@@ -91,7 +91,7 @@ func (emitter *Emitter) RemoveListener(event, listener interface{}) *Emitter {
 		}
 
 		for i, listener := range events {
-			if fn == listener {
+			if fn.Pointer() == listener.Pointer() {
 				// Do not break here to ensure the listener has not been
 				// added more than once.
 				emitter.events[event] = append(emitter.events[event][:i], emitter.events[event][i+1:]...)

--- a/emitter.go
+++ b/emitter.go
@@ -90,13 +90,15 @@ func (emitter *Emitter) RemoveListener(event, listener interface{}) *Emitter {
 			fn = emitter.onces[fn]
 		}
 
-		for i, listener := range events {
-			if fn.Pointer() == listener.Pointer() {
-				// Do not break here to ensure the listener has not been
-				// added more than once.
-				emitter.events[event] = append(emitter.events[event][:i], emitter.events[event][i+1:]...)
+		newEvents := []reflect.Value{}
+
+		for _, listener := range events {
+			if fn.Pointer() != listener.Pointer() {
+				newEvents = append(newEvents, listener)
 			}
 		}
+
+		emitter.events[event] = newEvents
 	}
 
 	return emitter

--- a/emitter_test.go
+++ b/emitter_test.go
@@ -129,3 +129,19 @@ func TestCountListener(t *testing.T) {
 		t.Error("Failed to get listener count from emitter.")
 	}
 }
+
+type SomeType struct{}
+
+func (*SomeType) Receiver(evt string) {}
+
+func TestRemoveStructMethod(t *testing.T) {
+	event := "test"
+	listener := &SomeType{}
+	emitter := NewEmitter().AddListener(event, listener.Receiver)
+
+	emitter.RemoveListener(event, listener.Receiver)
+	if 0 != emitter.GetListenerCount(event) {
+		t.Error("Failed to remove listener from emitter.")
+	}
+
+}

--- a/emitter_test.go
+++ b/emitter_test.go
@@ -143,5 +143,12 @@ func TestRemoveStructMethod(t *testing.T) {
 	if 0 != emitter.GetListenerCount(event) {
 		t.Error("Failed to remove listener from emitter.")
 	}
+}
 
+func TestRemoveDoubleListener(t *testing.T) {
+	event := "test"
+
+	fn1 := func() {}
+
+	NewEmitter().On(event, fn1).On(event, fn1).RemoveListener(event, fn1)
 }


### PR DESCRIPTION
One can use struct method as listener, but Removing such listeners fails. This PR fixes that.
Also fixed panic when removing double listeners