### PR TITLE
allow removal of closures, fixes #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ func main() {
     }
   }
   
-  emitter.On("hello", hello).
-    On("count", count).
-    Emit("hello", "world").
-    Emit("count", 5)
+  emitter.On("hello", hello)
+  emitter.On("count", count)
+  emitter.Emit("hello", "world")
+  emitter.Emit("count", 5)
 }
 
 ```

--- a/emitter.go
+++ b/emitter.go
@@ -105,7 +105,11 @@ func (emitter *Emitter) RemoveListener(event interface{}, listenerHandle Listene
 			}
 		}
 
-		emitter.events[event] = newEvents
+		if len(newEvents) > 0 {
+			emitter.events[event] = newEvents
+		} else {
+			delete(emitter.events,event)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixing this required changing the interface, you can no longer remove listeners
by function reference, but have to use an explicit `handle` which is returned
when your listener is added.

Merging this will break your interface, and so probably isn't something you
want to do - but maybe it will give some ideas on a more backwards
compatible fix.